### PR TITLE
Support arbitrary Racket expressions in `fanout`

### DIFF
--- a/profile/forms.rkt
+++ b/profile/forms.rkt
@@ -630,14 +630,23 @@
 (module fanout "forms-base.rkt"
   (provide run)
 
-  (define (fanout . vs)
+  (define (fanout-small-n . vs)
     (apply (☯ (fanout 3))
            vs))
 
+  (define (fanout-large-n . vs)
+    (apply (☯ (fanout 100))
+           vs))
+
   (define (run)
-    (run-benchmark fanout
-                   check-values
-                   500000)))
+    (run-summary-benchmark "fanout"
+                           +
+                           (fanout-small-n
+                            check-values
+                            200000)
+                           (fanout-large-n
+                            check-values
+                            20000))))
 
 (module inverter "forms-base.rkt"
   (provide run)

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -366,33 +366,15 @@ provide appropriate error messages at the level of the DSL.
   ;; high level routing
   [(_ (~datum fanout))
    #'repeat-values]
-  ;; [(_ ((~datum fanout) n:number))
-  ;;  (datum->syntax this-syntax
-  ;;    (list 'flow
-  ;;          (cons '-<
-  ;;                (repeat (syntax->datum #'n)
-  ;;                        '_))))]
-  ;; [(_ ({~datum fanout} n:expr))
-  ;;  #'(lambda args
-  ;;      (apply values
-  ;;             (apply append
-  ;;                    (build-list n (thunk* args)))))]
-  [(_ ({~datum fanout} n:expr))
+  [(_ ((~datum fanout) n:number))
+   #`(λ args
+       (apply values
+              (append #,@(repeat (syntax->datum #'n) 'args))) )]
+  [(_ ((~datum fanout) n:expr))
    #'(lambda args
        (apply values
               (apply append
                      (repeat n args))))]
-  ;; [(_ ({~datum fanout} n:expr))
-  ;;  #'(lambda args
-  ;;      (apply values
-  ;;             (apply append
-  ;;                    (make-list n args))))]
-  ;; [(_ ({~datum fanout} n:expr))
-  ;;  #'(lambda args (apply repeat-values n args))]
-  ;; [(_ ({~datum fanout} n:expr))
-  ;;  #'(flow (repeat-values n __))]
-  ;; [(_ ({~datum fanout} n:expr))
-  ;;  #'(flow (~>> (repeat-values n)))]
   [(_ ((~datum feedback) ((~datum while) tilex:clause)
                          ((~datum then) thenex:clause)
                          onex:clause))

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -364,12 +364,28 @@ provide appropriate error messages at the level of the DSL.
   ;; high level routing
   [(_ (~datum fanout))
    #'repeat-values]
-  [(_ ((~datum fanout) n:number))
-   (datum->syntax this-syntax
-     (list 'flow
-           (cons '-<
-                 (repeat (syntax->datum #'n)
-                         '_))))]
+  ;; [(_ ((~datum fanout) n:number))
+  ;;  (datum->syntax this-syntax
+  ;;    (list 'flow
+  ;;          (cons '-<
+  ;;                (repeat (syntax->datum #'n)
+  ;;                        '_))))]
+  ;; [(_ ({~datum fanout} n:expr))
+  ;;  #'(lambda args
+  ;;      (apply values
+  ;;             (apply append
+  ;;                    (build-list n (thunk* args)))))]
+  [(_ ({~datum fanout} n:expr))
+   #'(lambda args
+       (apply values
+              (apply append
+                     (repeat n args))))]
+  ;; [(_ ({~datum fanout} n:expr))
+  ;;  #'(lambda args (apply repeat-values n args))]
+  ;; [(_ ({~datum fanout} n:expr))
+  ;;  #'(flow (repeat-values n __))]
+  ;; [(_ ({~datum fanout} n:expr))
+  ;;  #'(flow (~>> (repeat-values n)))]
   [(_ ((~datum feedback) ((~datum while) tilex:clause)
                          ((~datum then) thenex:clause)
                          onex:clause))

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -17,8 +17,9 @@
                      racket/string
                      syntax/parse
                      racket/match
+                     (only-in racket/list
+                              make-list)
                      (only-in "private/util.rkt"
-                              repeat
                               report-syntax-error))
          (only-in qi/macro
                   qi-macro?
@@ -367,14 +368,16 @@ provide appropriate error messages at the level of the DSL.
   [(_ (~datum fanout))
    #'repeat-values]
   [(_ ((~datum fanout) n:number))
+   ;; a slightly more efficient compile-time implementation
+   ;; for literally indicated N
    #`(λ args
        (apply values
-              (append #,@(repeat (syntax->datum #'n) 'args))) )]
+              (append #,@(make-list (syntax->datum #'n) 'args))) )]
   [(_ ((~datum fanout) n:expr))
    #'(lambda args
        (apply values
               (apply append
-                     (repeat n args))))]
+                     (make-list n args))))]
   [(_ ((~datum feedback) ((~datum while) tilex:clause)
                          ((~datum then) thenex:clause)
                          onex:clause))

--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -10,6 +10,8 @@
          (only-in adjutor
                   values->list)
          racket/function
+         (only-in racket/list
+                  make-list)
          mischief/shorthand
          (for-syntax racket/base
                      racket/string
@@ -380,6 +382,11 @@ provide appropriate error messages at the level of the DSL.
        (apply values
               (apply append
                      (repeat n args))))]
+  ;; [(_ ({~datum fanout} n:expr))
+  ;;  #'(lambda args
+  ;;      (apply values
+  ;;             (apply append
+  ;;                    (make-list n args))))]
   ;; [(_ ({~datum fanout} n:expr))
   ;;  #'(lambda args (apply repeat-values n args))]
   ;; [(_ ({~datum fanout} n:expr))

--- a/qi-lib/private/util.rkt
+++ b/qi-lib/private/util.rkt
@@ -15,7 +15,6 @@
          arg
          except-args
          call
-         repeat
          repeat-values
          power
          foldl-values
@@ -198,16 +197,11 @@
 
 (define none? (compose not not ~none?))
 
-(define (repeat n v)
-  (if (= 0 n)
-      null
-      (cons v (repeat (sub1 n) v))))
-
 (define (repeat-values n . vs)
-  (apply values (apply append (repeat n vs))))
+  (apply values (apply append (make-list n vs))))
 
 (define (power n f)
-  (apply compose (repeat n f)))
+  (apply compose (make-list n f)))
 
 (define (foldl-values f init . vs)
   (let loop ([vs vs]

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -868,7 +868,14 @@
                    "control form of fanout")
      (check-equal? (~> (3 "a" "b") fanout string-append)
                    "ababab"
-                   "control form of fanout"))
+                   "control form of fanout")
+     (check-equal? (~> (5) (fanout (add1 2)) ▽)
+                   (list 5 5 5)
+                   "arbitrary racket expressions and not just literals")
+     (check-equal? (let ([n 3])
+                     (~> (5) (fanout n) ▽))
+                   (list 5 5 5)
+                   "arbitrary racket expressions and not just literals"))
     (test-suite
      "inverter"
      (check-false ((☯ (~> inverter

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -231,8 +231,7 @@
                    10)
      (check-exn exn:fail:contract?
                 (thunk ((☯ (~> △ +))
-                        #(1 2 3 4)))
-                10)
+                        #(1 2 3 4))))
      (check-equal? ((☯ (~> (△ +) ▽)) (list 1 2 3) 10)
                    (list 11 12 13)
                    "separate into a flow with presupplied values")

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -875,7 +875,16 @@
      (check-equal? (let ([n 3])
                      (~> (5) (fanout n) ▽))
                    (list 5 5 5)
-                   "arbitrary racket expressions and not just literals"))
+                   "arbitrary racket expressions and not just literals")
+     (check-equal? (~> (2 3) (fanout 0) ▽)
+                   null
+                   "N=0 produces no values.")
+     (check-equal? (~> () (fanout 3) ▽)
+                   null
+                   "No inputs produces no outputs.")
+     (check-exn exn:fail:contract?
+                (thunk (~> (-1 3) fanout ▽))
+                "Negative N signals an error."))
     (test-suite
      "inverter"
      (check-false ((☯ (~> inverter


### PR DESCRIPTION
### Summary of Changes

This implements the fix for #32 .

I tried six variations on the implementation (many suggested by @benknoble in #32 ) and profiled each using:

```
$ racket profile/forms.rkt -f fanout
```
(which, you can also get this command by running `make profile-selected-forms`)

Using `repeat` instead of `build-list` seemed to be the fastest -- faster even than the original syntactic version for numbers! I'm not sure why this might be, and I also haven't tried it on large `N`, where maybe the results would be different. Just putting it up for now for any initial feedback.

All of the variations are in the flow.rkt file and are currently commented out, except the one that's performing the fastest at the moment. For reference, [this is the benchmark](https://github.com/countvajhula/qi/blob/7d441ef2171b2d17d3dc70773c0903c1757d615b/profile/forms.rkt#L630-L640) that is run with the above command. Just like all the other benchmarks currently in that file, it is rudimentary, just a "smoke" benchmark (as in "smoke test") to get some rough sense of performance (ideas for improvement welcome!).

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
