### PR TITLE
Don't get too fancy

### DIFF
--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -6,7 +6,7 @@
                      clause))
 
 (require syntax/parse/define
-         fancy-app
+         (prefix-in fancy: fancy-app)
          (only-in adjutor
                   values->list)
          racket/function
@@ -517,13 +517,13 @@ provide appropriate error messages at the level of the DSL.
   ;; Fine-grained template-based application
   ;; This handles templates that indicate a specific number of template
   ;; variables (i.e. expected arguments). The semantics of template-based
-  ;; application here is fulfilled by the fancy-app module and we don't
-  ;; need to do anything special to handle it, since the #%app macro
-  ;; in the present module's scope is the one provided by fancy-app
+  ;; application here is fulfilled by the fancy-app module. In order to use
+  ;; it, we simply use the #%app macro provided by fancy-app instead of the
+  ;; implicit one used for function application in racket/base.
   [(_ (natex prarg-pre ... (~datum _) prarg-post ...))
-   #'(natex prarg-pre ...
-            _
-            prarg-post ...)]
+   #'(fancy:#%app natex prarg-pre ...
+                  _
+                  prarg-post ...)]
 
   ;; Pre-supplied arguments without a template
   [(_ (natex prarg ...+))

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -614,7 +614,7 @@
                 (thunk (parameterize ([current-namespace (make-base-empty-namespace)])
                          (namespace-require 'racket/base)
                          (namespace-require 'qi)
-                         (eval (read (open-input-string "(☯ (feedback _ add1))"))
+                         (eval '(☯ (feedback _ add1))
                                (current-namespace))))
                 "invalid syntax accepted on the basis of an assumed fancy-app template")))
 

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -573,7 +573,7 @@
                         5 7 8))
                 "function isn't curried when no arguments are provided"))
     (test-suite
-     "simple template"
+     "blanket template"
      (check-equal? ((☯ (+ __))) 0)
      (check-equal? ((☯ (string-append __))
                     "a" "b")
@@ -607,7 +607,16 @@
      (check-true ((☯ (< 1 _ 5 _ 10)) 3 7)
                  "template with multiple arguments")
      (check-false ((☯ (< 1 _ 5 _ 10)) 3 5)
-                  "template with multiple arguments")))
+                  "template with multiple arguments"))
+    (test-suite
+     "templating behavior is contained to intentional template syntax"
+     (check-exn exn:fail:syntax?
+                (thunk (parameterize ([current-namespace (make-base-empty-namespace)])
+                         (namespace-require 'racket/base)
+                         (namespace-require 'qi)
+                         (eval (read (open-input-string "(☯ (feedback _ add1))"))
+                               (current-namespace))))
+                "invalid syntax accepted on the basis of an assumed fancy-app template")))
 
    (test-suite
     "conditionals"


### PR DESCRIPTION
### Summary of Changes

Requiring `fancy-app` wholesale in the `flow.rkt` module means that the `flow` macro essentially defers control over expanding user-provided syntax to `fancy-app` when no expansion rule is matched. This is hazardous since it may lead to invalid syntax being accepted, if the third party macro (in this case fancy-app's `#%app`) happens to interpret certain literals in the user's code in some way that we don't expect.

Instead, we'd like to defer to fancy-app specifically in the cases where we have determined that it is applicable, i.e. in the case of Qi, specifically for fine-grained partial application templates.

This PR adopts @rocketnia's suggestion (in #33) to the effect by employing fancy-app's `#%app` only in the partial application expansion rule for fine-grained templates, rather than module-wide.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
