### PR TITLE
Add backup docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,6 @@
 name: docs
 
-on:
-  workflow_run:
-    workflows: [build]
-    types: [completed]
+on: [push, pull_request]
 
 defaults:
   run:
@@ -14,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and deploy backup docs
     environment: test-env
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,6 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     name: Build and deploy backup docs
-    environment: test-env
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: docs
 
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
 
 defaults:
   run:
@@ -11,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and deploy backup docs
     environment: test-env
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v1.3.1
+        uses: Bogdanp/setup-racket@v1.8.1
         with:
           architecture: 'x64'
           distribution: 'full'
@@ -31,7 +31,7 @@ jobs:
       - name: Build docs for hosting
         run: make build-standalone-docs
       - name: Push to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@4.3.3
         with:
           folder: docs/qi
           branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,12 @@
 name: docs
 
 on:
-  workflow_run:
-    workflows: [build]
-    types: [completed]
+  push:
+    branches:
+      - main
+    paths:
+      - 'qi-doc/scribblings/**'
+      - '.github/workflows/docs.yml'
 
 defaults:
   run:
@@ -14,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and deploy backup docs
     environment: test-env
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -27,10 +29,10 @@ jobs:
           version: 'stable'
       - name: Install Package and its Dependencies
         run: make install
-      - name: Build docs
-        run: make build-docs
+      - name: Build docs for hosting
+        run: make build-packaged-docs
       - name: Push to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          folder: qi-doc/doc
+          folder: docs/qi
           branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Package and its Dependencies
         run: make install
       - name: Build docs for hosting
-        run: make build-packaged-docs
+        run: make build-standalone-docs
       - name: Push to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: docs
+
+on:
+  workflow_run:
+    workflows: [build]
+    types: [completed]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    name: Build and deploy backup docs
+    environment: test-env
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Install Racket
+        uses: Bogdanp/setup-racket@v1.3.1
+        with:
+          architecture: 'x64'
+          distribution: 'full'
+          variant: 'CS'
+          version: 'stable'
+      - name: Install Package and its Dependencies
+        run: make install
+      - name: Build docs
+        run: make build-docs
+      - name: Push to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          folder: qi-doc/doc
+          branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build docs for hosting
         run: make build-standalone-docs
       - name: Push to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.3.3
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
           folder: docs/qi
           branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: docs
 
 on:
   push:
-    branches:
-      - main
     paths:
       - 'qi-doc/scribblings/**'
       - '.github/workflows/docs.yml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: docs
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'qi-doc/scribblings/**'
       - '.github/workflows/docs.yml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v1.3.1
+        uses: Bogdanp/setup-racket@v1.8.1
         with:
           architecture: 'x64'
           distribution: 'full'
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v1.3.1
+        uses: Bogdanp/setup-racket@v1.8.1
         with:
           architecture: 'x64'
           distribution: 'full'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,3 @@ jobs:
         run: make install
       - name: Build docs
         run: make build-docs
-      - name: Push to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.4
-        with:
-          folder: qi-doc/doc
-          branch: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,3 +77,8 @@ jobs:
         run: make install
       - name: Build docs
         run: make build-docs
+      - name: Push to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          folder: qi-doc/doc
+          branch: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,22 @@ jobs:
         run: make install
       - name: Report Coverage
         run: make cover-coveralls
+  docs:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Build and deploy backup docs
+    environment: test-env
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Install Racket
+        uses: Bogdanp/setup-racket@v1.3.1
+        with:
+          architecture: 'x64'
+          distribution: 'full'
+          variant: 'CS'
+          version: 'stable'
+      - name: Install Package and its Dependencies
+        run: make install
+      - name: Build docs
+        run: make build-docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,22 +58,3 @@ jobs:
         run: make install
       - name: Report Coverage
         run: make cover-coveralls
-  docs:
-    needs: test
-    runs-on: ubuntu-latest
-    name: Build and deploy backup docs
-    environment: test-env
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-      - name: Install Racket
-        uses: Bogdanp/setup-racket@v1.3.1
-        with:
-          architecture: 'x64'
-          distribution: 'full'
-          variant: 'CS'
-          version: 'stable'
-      - name: Install Package and its Dependencies
-        run: make install
-      - name: Build docs
-        run: make build-docs

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ DEPS-FLAGS=--check-pkg-deps --unused-pkg-deps
 
 help:
 	@echo "install - install package along with dependencies"
+	@echo "remove - remove package"
 	@echo "build - Compile libraries"
 	@echo "build-docs - Build docs"
 	@echo "build-all - Compile libraries, build docs, and check dependencies"

--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,18 @@ remove:
 # Primarily for day-to-day dev.
 # Build libraries from source.
 build:
-	raco setup --no-docs --tidy --pkgs $(PACKAGE-NAME)-lib
+	raco setup --no-docs --tidy --avoid-main --pkgs $(PACKAGE-NAME)-lib
 
 # Primarily for day-to-day dev.
 # Build docs (if any).
 build-docs:
 	raco setup --no-launcher --no-foreign-libs --no-info-domain --no-pkg-deps \
-	--no-install --no-post-install --tidy --pkgs $(PACKAGE-NAME)-doc
+	--no-install --no-post-install --tidy --avoid-main --pkgs $(PACKAGE-NAME)-doc
 
 # Primarily for day-to-day dev.
 # Build libraries from source, build docs (if any), and check dependencies.
 build-all:
-	raco setup --tidy $(DEPS-FLAGS) --pkgs $(PACKAGE-NAME)-{lib,test,doc,probe} $(PACKAGE-NAME)
+	raco setup --tidy --avoid-main $(DEPS-FLAGS) --pkgs $(PACKAGE-NAME)-{lib,test,doc,probe} $(PACKAGE-NAME)
 
 # Note: Each collection's info.rkt can say what to clean, for example
 # (define clean '("compiled" "doc" "doc/<collect>")) to clean

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "remove - remove package"
 	@echo "build - Compile libraries"
 	@echo "build-docs - Build docs"
-	@echo "build-packaged-docs - Build self-contained docs that could be hosted somewhere"
+	@echo "build-standalone-docs - Build self-contained docs that could be hosted somewhere"
 	@echo "build-all - Compile libraries, build docs, and check dependencies"
 	@echo "clean - remove all build artifacts"
 	@echo "check-deps - check dependencies"
@@ -66,7 +66,7 @@ build-all:
 
 # Primarily for CI, for building backup docs that could be used in case
 # the main docs at docs.racket-lang.org become unavailable.
-build-packaged-docs:
+build-standalone-docs:
 	scribble +m --redirect-main http://pkg-build.racket-lang.org/doc/ --htmls --dest ./docs ./qi-doc/scribblings/qi.scrbl
 
 # Note: Each collection's info.rkt can say what to clean, for example

--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,18 @@ remove:
 # Primarily for day-to-day dev.
 # Build libraries from source.
 build:
-	raco setup --no-docs --tidy --avoid-main --pkgs $(PACKAGE-NAME)-lib
+	raco setup --no-docs --pkgs $(PACKAGE-NAME)-lib
 
 # Primarily for day-to-day dev.
 # Build docs (if any).
 build-docs:
 	raco setup --no-launcher --no-foreign-libs --no-info-domain --no-pkg-deps \
-	--no-install --no-post-install --tidy --avoid-main --pkgs $(PACKAGE-NAME)-doc
+	--no-install --no-post-install --pkgs $(PACKAGE-NAME)-doc
 
 # Primarily for day-to-day dev.
 # Build libraries from source, build docs (if any), and check dependencies.
 build-all:
-	raco setup --tidy --avoid-main $(DEPS-FLAGS) --pkgs $(PACKAGE-NAME)-{lib,test,doc,probe} $(PACKAGE-NAME)
+	raco setup $(DEPS-FLAGS) --pkgs $(PACKAGE-NAME)-{lib,test,doc,probe} $(PACKAGE-NAME)
 
 # Note: Each collection's info.rkt can say what to clean, for example
 # (define clean '("compiled" "doc" "doc/<collect>")) to clean

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ DEPS-FLAGS=--check-pkg-deps --unused-pkg-deps
 
 help:
 	@echo "install - install package along with dependencies"
-	@echo "remove - remove package"
 	@echo "build - Compile libraries"
 	@echo "build-docs - Build docs"
 	@echo "build-all - Compile libraries, build docs, and check dependencies"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 	@echo "remove - remove package"
 	@echo "build - Compile libraries"
 	@echo "build-docs - Build docs"
+	@echo "build-packaged-docs - Build self-contained docs that could be hosted somewhere"
 	@echo "build-all - Compile libraries, build docs, and check dependencies"
 	@echo "clean - remove all build artifacts"
 	@echo "check-deps - check dependencies"
@@ -62,6 +63,11 @@ build-docs:
 # Build libraries from source, build docs (if any), and check dependencies.
 build-all:
 	raco setup $(DEPS-FLAGS) --pkgs $(PACKAGE-NAME)-{lib,test,doc,probe} $(PACKAGE-NAME)
+
+# Primarily for CI, for building backup docs that could be used in case
+# the main docs at docs.racket-lang.org become unavailable.
+build-packaged-docs:
+	scribble +m --redirect-main http://pkg-build.racket-lang.org/doc/ --htmls --dest ./docs ./qi-doc/scribblings/qi.scrbl
 
 # Note: Each collection's info.rkt can say what to clean, for example
 # (define clean '("compiled" "doc" "doc/<collect>")) to clean

--- a/qi-doc/scribblings/intro.scrbl
+++ b/qi-doc/scribblings/intro.scrbl
@@ -28,8 +28,6 @@
 
 @section{Overview}
 
-Test.
-
 One way to structure computations -- the one we typically employ when writing functions in Racket or another programming language -- is as a flowchart, with arrows representing transitions of control, indicating the sequence in which actions are performed. Aside from the implied ordering, the actions are independent of one another and could be anything at all. Another way -- provided by the present module -- is to structure computations as a fluid flow, like a flow of energy, electricity passing through a circuit, streams flowing around rocks. Here, arrows represent that actions feed into one another.
 
 The former way is often necessary when writing functions at a low level, where the devil is in the details. But once these functional building blocks are available, the latter model is often more appropriate, allowing us to compose functions at a high level to derive complex and robust functional pipelines from simple components with a minimum of repetition and boilerplate, engendering @hyperlink["https://www.theschooloflife.com/thebookoflife/wu-wei-doing-nothing/"]{effortless clarity}. The facilities in the present module allow you to employ this flow-oriented model in any source program.

--- a/qi-doc/scribblings/intro.scrbl
+++ b/qi-doc/scribblings/intro.scrbl
@@ -28,8 +28,6 @@
 
 @section{Overview}
 
-Intro. Test.
-
 One way to structure computations -- the one we typically employ when writing functions in Racket or another programming language -- is as a flowchart, with arrows representing transitions of control, indicating the sequence in which actions are performed. Aside from the implied ordering, the actions are independent of one another and could be anything at all. Another way -- provided by the present module -- is to structure computations as a fluid flow, like a flow of energy, electricity passing through a circuit, streams flowing around rocks. Here, arrows represent that actions feed into one another.
 
 The former way is often necessary when writing functions at a low level, where the devil is in the details. But once these functional building blocks are available, the latter model is often more appropriate, allowing us to compose functions at a high level to derive complex and robust functional pipelines from simple components with a minimum of repetition and boilerplate, engendering @hyperlink["https://www.theschooloflife.com/thebookoflife/wu-wei-doing-nothing/"]{effortless clarity}. The facilities in the present module allow you to employ this flow-oriented model in any source program.

--- a/qi-doc/scribblings/intro.scrbl
+++ b/qi-doc/scribblings/intro.scrbl
@@ -28,6 +28,8 @@
 
 @section{Overview}
 
+Test.
+
 One way to structure computations -- the one we typically employ when writing functions in Racket or another programming language -- is as a flowchart, with arrows representing transitions of control, indicating the sequence in which actions are performed. Aside from the implied ordering, the actions are independent of one another and could be anything at all. Another way -- provided by the present module -- is to structure computations as a fluid flow, like a flow of energy, electricity passing through a circuit, streams flowing around rocks. Here, arrows represent that actions feed into one another.
 
 The former way is often necessary when writing functions at a low level, where the devil is in the details. But once these functional building blocks are available, the latter model is often more appropriate, allowing us to compose functions at a high level to derive complex and robust functional pipelines from simple components with a minimum of repetition and boilerplate, engendering @hyperlink["https://www.theschooloflife.com/thebookoflife/wu-wei-doing-nothing/"]{effortless clarity}. The facilities in the present module allow you to employ this flow-oriented model in any source program.

--- a/qi-doc/scribblings/intro.scrbl
+++ b/qi-doc/scribblings/intro.scrbl
@@ -28,6 +28,8 @@
 
 @section{Overview}
 
+Intro. Test.
+
 One way to structure computations -- the one we typically employ when writing functions in Racket or another programming language -- is as a flowchart, with arrows representing transitions of control, indicating the sequence in which actions are performed. Aside from the implied ordering, the actions are independent of one another and could be anything at all. Another way -- provided by the present module -- is to structure computations as a fluid flow, like a flow of energy, electricity passing through a circuit, streams flowing around rocks. Here, arrows represent that actions feed into one another.
 
 The former way is often necessary when writing functions at a low level, where the devil is in the details. But once these functional building blocks are available, the latter model is often more appropriate, allowing us to compose functions at a high level to derive complex and robust functional pipelines from simple components with a minimum of repetition and boilerplate, engendering @hyperlink["https://www.theschooloflife.com/thebookoflife/wu-wei-doing-nothing/"]{effortless clarity}. The facilities in the present module allow you to employ this flow-oriented model in any source program.


### PR DESCRIPTION
### Summary of Changes

(This idea was suggested by @samdphillips)

In the event of build failures, either in Qi itself or in one of its upstream dependencies, docs on the Racket website become unavailable. Even in cases where it's a Qi error that we have control over, it could take up to 24 hours before the docs are rebuilt and become available again. This adds a CI workflow to build and deploy docs to a GitHub Pages site for this repo, so that these are available as a public backup in case the main docs go down.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
