### PR TITLE
Accurate performance baseline

### DIFF
--- a/profile/competitive.rkt
+++ b/profile/competitive.rkt
@@ -62,7 +62,7 @@
                            ping
                            10000)
 
-(define check-value-primes (curryr check-value (list 100 200 300)))
+(define check-value-primes (curryr check-value #(100 200 300)))
 
 (run-competitive-benchmark "Eratosthenes"
                            check-value-primes

--- a/profile/util.rkt
+++ b/profile/util.rkt
@@ -53,16 +53,23 @@
       (set! i (remainder (add1 i) len))
       (fn (vector-ref inputs i)))))
 
+;; This uses the same list input each time. Not sure if that
+;; may end up being cached at some level and thus obfuscate
+;; the results? On the other hand,
+;; the cost of constructing a varying list each time ends up
+;; taking up a nontrivial fraction of the total time spent
 (define (check-list fn how-many)
   ;; call a function with a single list argument
-  (for ([i (in-range how-many)])
-    (let ([vs (range i (+ i 10))])
+  (let ([vs (range 10)])
+    (for ([i how-many])
       (fn vs))))
 
+;; This uses the same input values each time. See the note
+;; above for check-list in this connection.
 (define (check-values fn how-many)
   ;; call a function with multiple values as independent arguments
-  (for ([i (in-range how-many)])
-    (let ([vs (range i (+ i 10))])
+  (let ([vs (range 10)])
+    (for ([i how-many])
       (call-with-values (λ ()
                           (apply values vs))
                         fn))))

--- a/profile/util.rkt
+++ b/profile/util.rkt
@@ -42,10 +42,15 @@
 (define (measure fn . args)
   (second (values->list (time-apply fn args))))
 
-(define (check-value fn how-many [inputs (range 10)])
+;; This uses a vector of inputs so that indexing into it
+;; is constant time and doesn't factor prominently in the
+;; overall time taken.
+(define (check-value fn how-many [inputs #(0 1 2 3 4 5 6 7 8 9)])
   ;; call a function with a single (numeric) argument
-  (for ([i (take how-many (cycle inputs))])
-    (fn i)))
+  (let ([i 0])
+    (for ([j how-many])
+      (set! i (remainder (add1 i) 10))
+      (fn (vector-ref inputs i)))))
 
 (define (check-list fn how-many)
   ;; call a function with a single list argument

--- a/profile/util.rkt
+++ b/profile/util.rkt
@@ -47,9 +47,10 @@
 ;; overall time taken.
 (define (check-value fn how-many [inputs #(0 1 2 3 4 5 6 7 8 9)])
   ;; call a function with a single (numeric) argument
-  (let ([i 0])
+  (let ([i 0]
+        [len (vector-length inputs)])
     (for ([j how-many])
-      (set! i (remainder (add1 i) 10))
+      (set! i (remainder (add1 i) len))
       (fn (vector-ref inputs i)))))
 
 (define (check-list fn how-many)

--- a/profile/util.rkt
+++ b/profile/util.rkt
@@ -76,8 +76,8 @@
 
 (define (check-two-values fn how-many)
   ;; call a function with two values as arguments
-  (for ([i (in-range how-many)])
-    (let ([vs (range i (+ i 2))])
+  (let ([vs (list 5 7)])
+    (for ([i (in-range how-many)])
       (call-with-values (λ ()
                           (apply values vs))
                         fn))))


### PR DESCRIPTION
### Summary of Changes

I've addressed your comments on #20 , @michaelballantyne , and avoided constructing lists in the benchmarks. This results in a seemingly murderous advantage for Racket over Qi, as you predicted. Although, I'm not really sure what these benchmarks are telling us. These differences only become apparent at all on scales much finer than practical workloads would seem to involve (and e.g. benchmarks in libraries _using_ Qi are unaffected when using Qi vs Racket). So it might be like using bricks vs atoms to build a skyscraper, maybe - in practice it may not matter to the result, although using atoms might look nicer under a microscope. So I find myself wondering whether these benchmarks are actually useful in representing Qi vs Racket performance, and if not, what would be more useful / representative?

I'm also wondering what kinds of benchmarks would be useful as we undertake performance improvements once the compiler work is underway. Probably the forms benchmarks in `profile/forms` would be useful here, but those don't reflect non-local interactions.

At this point we probably just want to have some minimally accurate baseline against which future improvements / regressions could be seen with some confidence.

Would love to hear any thoughts you may have on this.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
