### PR TITLE
Add require latency to the tracked benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: Qi Forms Benchmarks
+          name: Qi Benchmarks
           tool: 'customSmallerIsBetter'
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks

--- a/profile/loadlib.rkt
+++ b/profile/loadlib.rkt
@@ -1,0 +1,48 @@
+#!/usr/bin/env racket
+#lang cli
+
+(provide time-racket
+         time-module-ms)
+
+(require racket/port
+         racket/format)
+
+#|
+This works by:
+1. Running `racket -l <module_name>` and `racket -l racket/base` independently
+2. Subtracting the latter from the former.
+3. Printing that result in milliseconds.
+
+where <module_name> is the argument you specified at the command line,
+e.g. ./loadlib.rkt racket/list
+
+The idea is to subtract out the contribution from racket/base, so that
+what remains is just the time contributed by requiring the specified module.
+|#
+
+(define (time-racket [module-name "racket/base"])
+  (define-values (sp out in err)
+    (subprocess #f #f #f (find-executable-path "time") "-p" (find-executable-path "racket") "-l" module-name))
+  (define result (port->string err))
+  (define seconds (string->number
+                   (car
+                    (regexp-match #px"[\\d|\\.]+"
+                                  (car
+                                   (regexp-match #rx"(?m:^real.*)"
+                                                 result))))))
+  (close-input-port out)
+  (close-output-port in)
+  (close-input-port err)
+  (subprocess-wait sp)
+  seconds)
+
+(define (time-module-ms module-name)
+  (* 1000
+     (- (time-racket module-name)
+        (time-racket))))
+
+(program (time-require module-name)
+  (displayln (~a (time-module-ms module-name) " ms")))
+
+(module+ main
+  (run time-require))

--- a/profile/report.rkt
+++ b/profile/report.rkt
@@ -63,6 +63,8 @@
  (prefix-in apply: (submod "forms.rkt" apply))
  (prefix-in clos: (submod "forms.rkt" clos)))
 
+(require "loadlib.rkt")
+
 (require racket/match
          racket/format
          relation
@@ -143,11 +145,13 @@
    "clos" clos:run))
 
 (program (main)
-  (let* ([forms (hash-keys env)]
-         [fs (~>> (forms)
-                  (sort <))])
-    (write-json (for/list ([f fs])
-                  (match-let ([(list name ms) ((hash-ref env f))])
-                    (hash 'name name 'unit "ms" 'value ms))))))
+  (define fs (~>> (env) hash-keys (sort <)))
+  (define forms-data (for/list ([f fs])
+                       (match-let ([(list name ms) ((hash-ref env f))])
+                         (hash 'name name 'unit "ms" 'value ms))))
+  (define require-data (list (hash 'name "(require qi)"
+                                   'unit "ms"
+                                   'value (time-module-ms "qi"))))
+  (write-json (append forms-data require-data)))
 
 (run main)

--- a/profile/report.rkt
+++ b/profile/report.rkt
@@ -145,8 +145,9 @@
    "clos" clos:run))
 
 (program (main)
+  ;; Note: could use try-order? with hash-keys if support is dropped for Racket 8.3
   (define fs (~>> (env) hash-keys (sort <)))
-  (define forms-data (for/list ([f fs])
+  (define forms-data (for/list ([f (in-list fs)])
                        (match-let ([(list name ms) ((hash-ref env f))])
                          (hash 'name name 'unit "ms" 'value ms))))
   (define require-data (list (hash 'name "(require qi)"


### PR DESCRIPTION
### Summary of Changes

This adds require time latency (measured via [loadlib.rkt](https://gist.github.com/countvajhula/33b43c488c9e384e87420140597783a4)) to the [tracked benchmarks](https://countvajhula.github.io/qi/benchmarks/).

For the moment this adds the `loadlib.rkt` script to the repo, but eventually if it is maintained as a separate developer tool (see #51 ), this can be removed in favor of using the external tool via `raco`.

**Question**: should we estimate a prelapsarian value and work it into the data manually?

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
