### PR TITLE
Prelapsarian require latency capture

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,18 +22,4 @@ jobs:
       - name: Install Package and its Dependencies
         run: make install
       - name: Run benchmark
-        run: make report-benchmarks | tee benchmarks.txt
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Qi Forms Benchmarks
-          tool: 'customSmallerIsBetter'
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: benchmarks
-          output-file-path: benchmarks.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'
-          comment-on-alert: true
-          fail-on-alert: true
+        run: make report-benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,9 +1,6 @@
 name: benchmarks
 
-on:
-  push:
-    branches:
-      - main
+on: [push]
 
 jobs:
   benchmark:

--- a/profile/loadlib.rkt
+++ b/profile/loadlib.rkt
@@ -1,0 +1,48 @@
+#!/usr/bin/env racket
+#lang cli
+
+(provide time-racket
+         time-module-ms)
+
+(require racket/port
+         racket/format)
+
+#|
+This works by:
+1. Running `racket -l <module_name>` and `racket -l racket/base` independently
+2. Subtracting the latter from the former.
+3. Printing that result in milliseconds.
+
+where <module_name> is the argument you specified at the command line,
+e.g. ./loadlib.rkt racket/list
+
+The idea is to subtract out the contribution from racket/base, so that
+what remains is just the time contributed by requiring the specified module.
+|#
+
+(define (time-racket [module-name "racket/base"])
+  (define-values (sp out in err)
+    (subprocess #f #f #f (find-executable-path "time") "-p" (find-executable-path "racket") "-l" module-name))
+  (define result (port->string err))
+  (define seconds (string->number
+                   (car
+                    (regexp-match #px"[\\d|\\.]+"
+                                  (car
+                                   (regexp-match #rx"(?m:^real.*)"
+                                                 result))))))
+  (close-input-port out)
+  (close-output-port in)
+  (close-input-port err)
+  (subprocess-wait sp)
+  seconds)
+
+(define (time-module-ms module-name)
+  (* 1000
+     (- (time-racket module-name)
+        (time-racket))))
+
+(program (time-require module-name)
+  (displayln (~a (time-module-ms module-name) " ms")))
+
+(module+ main
+  (run time-require))


### PR DESCRIPTION
### Summary of Changes

This PR *will not be merged*. It's just here to measure the require time latency on an older "prelapsarian" state of the code (i.e. right before "the fall" of the require latency 🐶 ), so that we can add an accurate data point in the tracked benchmark data. The data can be found in each run of the [benchmarks job for this branch](https://github.com/countvajhula/qi/actions/runs/2713890450), in the JSON output in the "run benchmark" step.

This branch is based on 3483112, although I'm not sure if the GitHub UI makes that clear anywhere.

FYI @benknoble 🙂 
