### PR TITLE
use pipefail in a step with a pipe

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install Package and its Dependencies
         run: make install
       - name: Run benchmark
+        shell: 'bash --noprofile --norc -eo pipefail {0}'
         run: make report-benchmarks | tee benchmarks.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
### Summary of Changes

This is _supposed_ to be the default according to
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id_stepsshell
but https://github.com/actions/runner/issues/353 indicates that this is
_still_ not really the case (but the end result is confusing), so we'll
be explicit here.

This might solve #56 

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
