### PR TITLE
[><]: Extend `><` to map input sequence.

### DIFF
--- a/qi-doc/scribblings/forms.scrbl
+++ b/qi-doc/scribblings/forms.scrbl
@@ -650,7 +650,7 @@ A form of generalized @racket[sieve], passing all the inputs that satisfy each
 @defform[#:link-target? #f
          (amp flo)]
 )]{
-  The flow analogue to @racket[map], this maps each input individually under @racket[flo]. As flows may generate any number of output values, unlike @racket[map], the number of outputs need not equal the number of inputs here.
+  The flow analogue to @racket[map], this maps the input sequence according to the procedure arity (prefer the least arity other than @racket[0]) of @racket[flo]. As flows may generate any number of output values, unlike @racket[map], the number of outputs need not equal the number of inputs here.
 
   If used in identifier form simply as @racket[><], it treats the first input as @racket[flo].
 
@@ -659,6 +659,15 @@ A form of generalized @racket[sieve], passing all the inputs that satisfy each
     ((☯ (>< sqr)) 1 2 3)
     ((☯ ><) sqr 1 2 3)
     ((☯ (>< (-< _ _))) 1 2 3)
+    ((☯ (>< 1)))
+    ((☯ (>< (esc (λ () 1)))))
+    ((☯ (>< (esc (case-lambda [(_) (add1 _)] [_ #f])))))
+    ((☯ (>< (esc (case-lambda [(_) (add1 _)] [_ #f])))) 1 2 3)
+    (~> ('k1 "v1" 'k2 "v2") (>< cons) ▽ make-immutable-hash)
+    (~> (1 2 1)
+        (>< (-< _ _))
+        (-< 0 _ 0)
+        (>< (esc (procedure-reduce-arity + 2))))
   ]
 }
 
@@ -692,7 +701,7 @@ A form of generalized @racket[sieve], passing all the inputs that satisfy each
 
 @examples[
     #:eval diagram-eval
-	#:result-only
+    #:result-only
     (set-curve-pict-size 200 200)
     (current-label-gap (px 8))
 

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -1193,7 +1193,38 @@
      (check-equal? ((☯ (~> (amp sqr) ▽))
                     3 5)
                    (list 9 25)
-                   "named amplification form"))
+                   "named amplification form")
+     (test-suite
+      "mapping sequence"
+      (check-equal? ((☯ (~> (>< 1) ▽))) '())
+      (check-equal? ((☯ (~> (>< (esc (λ () 1))) ▽))) '(1))
+      (check-equal? ((☯ (~> (>< (esc (case-lambda [(_) (add1 _)] [_ #f]))) ▽))) '())
+      (check-equal? ((☯ (~> (>< (esc (case-lambda [(_) (add1 _)] [_ #f]))) ▽)) 1 2 3) '(2 3 4))
+      (check-equal? ((☯ (~> (>< (esc (λ () 1))) ▽))) '(1))
+      (check-equal? ((☯ (~> (>< cons) ▽ make-immutable-hash))
+                     'k1 "v1"
+                     'k2 "v2")
+                    (hash
+                     'k1 "v1"
+                     'k2 "v2"))
+      (check-equal? ((☯
+                      (~> (>< (-< _ _))
+                          (-< 0 _ 0)
+                          (>< (esc (procedure-reduce-arity + 2)))
+                          ▽))
+                     1 2 1)
+                    '(1 3 3 1))
+      (check-equal? ((☯ (~> (>< member) ▽))
+                     1 '(1 2 3)
+                     2 '(a b c))
+                    '((1 2 3) #f))
+      (check-equal? ((☯ (~> (>< /) ▽)) 1 2 3)
+                    '(1 1/2 1/3))
+      (check-equal? ((☯ (~> >< ▽))
+                     cons
+                     1 2
+                     3 4)
+                    '((1 . 2) (3 . 4)))))
     (test-suite
      "pass"
      (check-equal? ((☯ (~> pass ▽))


### PR DESCRIPTION
### Summary of Changes

With this change, we can define `meru-step` in this way:
```racket
(define-flow meru-step
  (~> (>< (-< _ _)) (-< 0 _ 0)
      (>< (esc (procedure-reduce-arity + 2)))))

```

And I think it's useful in some cases:
```racket
(~> ('k1 "v1" 'k2 "v2") (>< cons) ▽ make-immutable-hash)

```

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
