### PR TITLE
[==*] Extend `==*` to represent `×`.

### DIFF
--- a/qi-lib/flow/compiler.rkt
+++ b/qi-lib/flow/compiler.rkt
@@ -101,9 +101,8 @@
      #'(qi0->racket (~> ▽ reverse △))]
     [((~or* (~datum ==) (~datum relay)) onex:clause ...)
      #'(relay (qi0->racket onex) ...)]
-    [((~or* (~datum ==*) (~datum relay*)) onex:clause ... rest-onex:clause)
-     (with-syntax ([len #`#,(length (syntax->list #'(onex ...)))])
-       #'(qi0->racket (group len (== onex ...) rest-onex) ))]
+    [((~or* (~datum ==*) (~datum relay*)) onex:clause ...)
+     #'(relay* (qi0->racket onex) ...)]
     [((~or* (~datum -<) (~datum tee)) onex:clause ...)
      #'(λ args
          (apply values

--- a/qi-test/tests/flow.rkt
+++ b/qi-test/tests/flow.rkt
@@ -484,18 +484,34 @@
                     5 7)
                    (list 25 8)
                    "named relay form"))
-    (test-suite
-     "==*"
-     (check-equal? ((☯ (~> (==* add1 sub1 +) ▽))
-                    1 1 1 1 1)
-                   (list 2 0 3))
-     (check-equal? ((☯ (~> (==* add1 sub1 +) ▽))
-                    1 1)
-                   (list 2 0 0))
-     (check-equal? ((☯ (~> (relay* add1 sub1 +) ▽))
-                    1 1 1 1 1)
-                   (list 2 0 3)
-                   "named relay* form"))
+    (let ([add (procedure-reduce-arity + 2)]
+          [mul (procedure-reduce-arity * 2)]
+          [id  (procedure-reduce-arity values 1)])
+      (test-suite
+       "==*"
+       (check-equal? ((☯ (~> (==* add1 sub1 +) ▽))
+                      1 1 1 1 1)
+                     (list 2 0 3))
+       (check-equal? ((☯ (~> (==* add1 + sub1) ▽))
+                      1 1 1 1 1)
+                     (list 2 3 0))
+       (check-equal? ((☯ (~> (==* add1 + + sub1) ▽))
+                      1 1 1 1 1)
+                     (list 2 1 2 0))
+       (check-equal? ((☯ (~> (==* add1 sub1 +) ▽))
+                      1 1)
+                     (list 2 0 0))
+       (check-equal? ((☯
+                        (~> (-< 1> 1> 1> 2> 3)  ; x x x y 3
+                            (==* mul  mul   id) ; x*x x*y 3
+                            (==* id   mul)      ; x*x x*y*3
+                            (==* add)))
+                      3 4)
+                     45)
+       (check-equal? ((☯ (~> (relay* add1 sub1 +) ▽))
+                      1 1 1 1 1)
+                     (list 2 0 3)
+                     "named relay* form")))
     (test-suite
      "ground"
      (check-equal? ((☯ (-< ⏚ add1))


### PR DESCRIPTION
### Summary of Changes

See https://github.com/countvajhula/qi/issues/62 .

Since it is uncertain whether Qi should support arity modeling, this PR is just a draft.

Original:
```
$ racket profile/forms.rkt -f "relay*"
relay*: 126 ms
```

New version:
```
$ racket profile/forms.rkt -f "relay*"
relay*: 128 ms
```

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
