### PR TITLE
Define identity elements for `tee` and `relay`.

### DIFF
--- a/qi-lib/flow/compiler.rkt
+++ b/qi-lib/flow/compiler.rkt
@@ -91,7 +91,7 @@
     ;;; Core routing elements
 
     [(~or* (~datum ⏚) (~datum ground))
-     #'(qi0->racket (select))]
+     #'*->1]
     [((~or* (~datum ~>) (~datum thread)) onex:clause ...)
      #`(compose . #,(reverse
                      (syntax->list
@@ -105,11 +105,7 @@
      (with-syntax ([len #`#,(length (syntax->list #'(onex ...)))])
        #'(qi0->racket (group len (== onex ...) rest-onex) ))]
     [((~or* (~datum -<) (~datum tee)) onex:clause ...)
-     #'(λ args
-         (apply values
-                (append (values->list
-                         (apply (qi0->racket onex) args))
-                        ...)))]
+     #'(tee (qi0->racket onex) ...)]
     [e:select-form (select-parser #'e)]
     [e:block-form (block-parser #'e)]
     [((~datum bundle) (n:number ...)
@@ -308,6 +304,7 @@ the DSL.
 
   (define (select-parser stx)
     (syntax-parse stx
+      [(_) #'*->1]
       [(_ n:number ...) #'(qi0->racket (-< (esc (arg n)) ...))]
       [(_ arg ...) ; error handling catch-all
        (report-syntax-error 'select
@@ -488,17 +485,14 @@ the DSL.
   (define (fanout-parser stx)
     (syntax-parse stx
       [_:id #'repeat-values]
+      [(_ 0) #'*->1]
       [(_ n:number)
        ;; a slightly more efficient compile-time implementation
        ;; for literally indicated N
        #`(λ args
            (apply values
                   (append #,@(make-list (syntax->datum #'n) 'args))) )]
-      [(_ n:expr)
-       #'(lambda args
-           (apply values
-                  (apply append
-                         (make-list n args))))]))
+      [(_ e:expr) #`(let ([n e]) (#,fanout-parser n))]))
 
   (define (feedback-parser stx)
     (syntax-parse stx


### PR DESCRIPTION
### Summary of Changes

As a kind of Cartesian Product, `Values`'s identity element `(values)` can be marked as `1`.

`-<` and [==*](https://github.com/countvajhula/qi/pull/69) can be regarded as monoids with identity elements `*->1` and `1->1` respectively.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
