### PR TITLE
Name

### DIFF
--- a/qi-lib/flow.rkt
+++ b/qi-lib/flow.rkt
@@ -41,7 +41,8 @@ in the flow macro.
        (let ([flowed #,((compose compile-flow expand-flow) #'onex)])
          (cond
            [(and 'name (procedure? flowed)
-                 (memq (object-name flowed) '(flowed composed)))
+                 (memq (object-name flowed)
+                       '(flowed composed #f)))
             (procedure-rename flowed 'name)]
            [else flowed])))]
     ;; a non-flow


### PR DESCRIPTION
### Summary of Changes
Inferring the names of procedures created by `☯`.

```racket
Welcome to Racket v8.6 [cs].
> (require qi)
> (object-name (☯ add1))
'add1
> (object-name (☯ (esc (lambda _ _))))
'flowed
> (define f (☯ (~> + + add1)))
> (object-name f)
'f
> (define g (☯ (esc (lambda _ _))))
> (object-name g)
'g
```

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
